### PR TITLE
Bugfix: Fix place preconditions so that the robot won't get caught in a loop during repositioning

### DIFF
--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -103,7 +103,7 @@ class PlaceObjectOperation(ManagedOperation):
         object_xyz = self.sample_placement_position(self.robot.get_base_pose())
         start = self.robot.get_base_pose()
         dist = np.linalg.norm(object_xyz[:2] - start[:2])
-        if dist > self.agent.manipulation_radius + self.place_step_size:
+        if dist > self.agent.manipulation_radius + self.place_step_size + self.agent.voxel_size:
             self.error(
                 f"Object is too far away to grasp: {dist} vs {self.agent.manipulation_radius + self.place_step_size}"
             )

--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -96,7 +96,9 @@ class PlaceObjectOperation(ManagedOperation):
         start = self.robot.get_base_pose()
         dist = np.linalg.norm(object_xyz[:2] - start[:2])
         if dist > self.agent.manipulation_radius + self.place_step_size:
-            self.error(f"Object is too far away to grasp: {dist}")
+            self.error(
+                f"Object is too far away to grasp: {dist} vs {self.agent.manipulation_radius + self.place_step_size}"
+            )
             return False
         self.cheer(f"Object is probably close enough to place upon: {dist}")
         return True

--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -87,7 +87,7 @@ class PlaceObjectOperation(ManagedOperation):
             print(" - After taking a step towards the center of the object, we are at", point)
             print(
                 " - Distance to the center of the object is",
-                np.linalg.norm(point[:2] - center_xyz[:2]),
+                np.linalg.norm(point[:2] - center_xyz[:2].cpu().numpy()),
             )
         return point
 

--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -87,7 +87,7 @@ class PlaceObjectOperation(ManagedOperation):
             print(" - After taking a step towards the center of the object, we are at", point)
             print(
                 " - Distance to the center of the object is",
-                np.linalg.norm(point[:2] - center_xyz[:2].cpu().numpy()),
+                np.linalg.norm(point[:2] - xyt[:2]),
             )
         return point
 

--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -26,6 +26,7 @@ class PlaceObjectOperation(ManagedOperation):
     show_place_in_voxel_grid: bool = False
     place_step_size: float = 0.25
     use_pitch_from_vertical: bool = True
+    verbose: bool = True
 
     def configure(
         self,
@@ -63,7 +64,8 @@ class PlaceObjectOperation(ManagedOperation):
 
         target = self.get_target()
         center_xyz = self.get_target_center()
-        print(" - Placing object on receptacle at", center_xyz)
+        if self.verbose:
+            print(" - Placing object on receptacle at", center_xyz)
 
         # Get the point cloud of the object and find distances to robot
         distances = (target.point_cloud[:, :2] - xyt[:2]).norm(dim=1)
@@ -71,8 +73,9 @@ class PlaceObjectOperation(ManagedOperation):
         idx = distances.argmin()
         # Get the point
         point = target.point_cloud[idx].cpu().numpy()
-        print(" - Closest point to robot is", point)
-        print(" - Distance to robot is", distances[idx])
+        if self.verbose:
+            print(" - Closest point to robot is", point)
+            print(" - Distance to robot is", distances[idx])
         # Compute distance to the center of the object
         distance = np.linalg.norm(point[:2] - center_xyz[:2].cpu().numpy())
         # Take a step towards the center of the object
@@ -80,10 +83,12 @@ class PlaceObjectOperation(ManagedOperation):
         point[:2] = point[:2] + (
             dxyz[:2] / np.linalg.norm(dxyz[:2]) * min(distance, self.place_step_size)
         )
-        print(" - After taking a step towards the center of the object, we are at", point)
-        print(
-            " - Distance to the center of the object is", np.linalg.norm(point[:2] - center_xyz[:2])
-        )
+        if self.verbose:
+            print(" - After taking a step towards the center of the object, we are at", point)
+            print(
+                " - Distance to the center of the object is",
+                np.linalg.norm(point[:2] - center_xyz[:2]),
+            )
         return point
 
     def can_start(self) -> bool:

--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -81,6 +81,9 @@ class PlaceObjectOperation(ManagedOperation):
             dxyz[:2] / np.linalg.norm(dxyz[:2]) * min(distance, self.place_step_size)
         )
         print(" - After taking a step towards the center of the object, we are at", point)
+        print(
+            " - Distance to the center of the object is", np.linalg.norm(point[:2] - center_xyz[:2])
+        )
         return point
 
     def can_start(self) -> bool:

--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -95,7 +95,7 @@ class PlaceObjectOperation(ManagedOperation):
         object_xyz = self.sample_placement_position(self.robot.get_base_pose())
         start = self.robot.get_base_pose()
         dist = np.linalg.norm(object_xyz[:2] - start[:2])
-        if dist > self.agent.manipulation_radius:
+        if dist > self.agent.manipulation_radius + self.place_step_size:
             self.error(f"Object is too far away to grasp: {dist}")
             return False
         self.cheer(f"Object is probably close enough to place upon: {dist}")

--- a/src/stretch/agent/operations/place_object.py
+++ b/src/stretch/agent/operations/place_object.py
@@ -103,6 +103,11 @@ class PlaceObjectOperation(ManagedOperation):
         object_xyz = self.sample_placement_position(self.robot.get_base_pose())
         start = self.robot.get_base_pose()
         dist = np.linalg.norm(object_xyz[:2] - start[:2])
+        # Check if the object is close enough to place upon
+        # We need to be within the manipulation radius + place_step_size + voxel_size
+        # Manipulation radius is the distance from the base to the end effector - this is what we actually plan for
+        # We take a step of size place_step_size towards the object center
+        # Base location sampling is often checked against voxel map - so we can have an error of up to voxel_size
         if dist > self.agent.manipulation_radius + self.place_step_size + self.agent.voxel_size:
             self.error(
                 f"Object is too far away to grasp: {dist} vs {self.agent.manipulation_radius + self.place_step_size}"

--- a/src/stretch/agent/robot_agent.py
+++ b/src/stretch/agent/robot_agent.py
@@ -424,6 +424,11 @@ class RobotAgent:
         self._update_scene_graph()
         return self.scene_graph
 
+    @property
+    def manipulation_radius(self) -> float:
+        """Return the manipulation radius"""
+        return self._manipulation_radius
+
     def plan_to_instance_for_manipulation(
         self,
         instance: Instance,

--- a/src/stretch/agent/robot_agent.py
+++ b/src/stretch/agent/robot_agent.py
@@ -94,12 +94,13 @@ class RobotAgent:
         self._frontier_min_dist = parameters["motion_planner"]["frontier"]["min_dist"]
         self._frontier_step_dist = parameters["motion_planner"]["frontier"]["step_dist"]
         self._manipulation_radius = parameters["motion_planner"]["goals"]["manipulation_radius"]
+        self._voxel_size = parameters["voxel_size"]
 
         if voxel_map is not None:
             self.voxel_map = voxel_map
         else:
             self.voxel_map = SparseVoxelMap(
-                resolution=parameters["voxel_size"],
+                resolution=self._voxel_size,
                 local_radius=parameters["local_radius"],
                 obs_min_height=parameters["obs_min_height"],
                 obs_max_height=parameters["obs_max_height"],
@@ -178,6 +179,11 @@ class RobotAgent:
     def feature_match_threshold(self) -> float:
         """Return the feature match threshold"""
         return self._is_match_threshold
+
+    @property
+    def voxel_size(self) -> float:
+        """Return the voxel size in meters"""
+        return self._voxel_size
 
     def get_encoder(self) -> BaseImageTextEncoder:
         """Return the encoder in use by this model"""


### PR DESCRIPTION
## Description

  - Place preconditions and navigation were two different things before
  - Read them from the same file

## Checklist

- \[ \] I have performed a self-review of my code
- \[ \] If it is a core feature, I have added thorough tests
- \[ \] I have added documentation for the changes
- \[ \] I have updated the README file if necessary
- \[ \] I have run on hardware if necessary

## Screenshots (if applicable)

Add any relevant screenshots or screen recordings to help reviewers understand the changes.

## Additional context

Add any other context or information about the pull request here.
