### PR TITLE
Add image captioners

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,12 @@
 *.mov filter=lfs diff=lfs merge=lfs -text
 *.avi filter=lfs diff=lfs merge=lfs -text
 
+# Images
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+
 # Data files
 *.csv filter=lfs diff=lfs merge=lfs -text
 *.CSV filter=lfs diff=lfs merge=lfs -text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,14 +103,33 @@ The [stretch_ros2_bridge](src/stretch_ros2_bridge) package is a ROS2 bridge that
 
 ##### Perception
 
+The perception package contains tools for perception, such as object detection and pose estimation.
+
+Here are some images you can use to test the perception tools:
+
+| Object Image | Receptacle Image |
+|--------------|------------------|
+| [![object.png](docs/object.png)](docs/object.png) | [![receptacle.png](docs/receptacle.png)](docs/receptacle.png) |
+
 You can try the captioners with:
 
 ```bash
 # Moonbeam captioner
 # Gives: "A plush toy resembling a spotted animal is lying on its back on a wooden floor, with its head and front paws raised."
-python -m stretch.perception.captioners.moonbeam_captioner --image_path <path_to_image>
+python -m stretch.perception.captioners.moonbeam_captioner --image_path object.png
+# Gives: "An open cardboard box rests on a wooden floor, with a stuffed animal lying next to it."
+python -m stretch.perception.captioners.moonbeam_captioner --image_path receptacle.png
 
 # ViT + GPT2 captioner
 # Gives: "a cat laying on the floor next to a door"
-python -m stretch.perception.captioners.vit_gpt2_captioner --image_path <path_to_image>
+python -m stretch.perception.captioners.vit_gpt2_captioner --image_path object.png
+# Gives: "a box with a cat laying on top of it"
+python -m stretch.perception.captioners.vit_gpt2_captioner --image_path receptacle.png
+
+# Blip Captioner
+# Gives: "a stuffed dog on the floor"
+python -m stretch.perception.captioners.blip_captioner --image_path object.png
+# Gives: "a dog laying on the floor next to a cardboard box"
+python -m stretch.perception.captioners.blip_captioner --image_path receptacle.png
+
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,9 @@ The code is organized as follows. Inside the core package `src/stretch`:
 - [app](src/stretch/app) contains individual endpoints, runnable as `python -m stretch.app.<app_name>`, such as mapping, discussed above.
 - [motion](src/stretch/motion) contains motion planning tools, including [algorithms](src/stretch/motion/algo) like RRT.
 - [mapping](src/stretch/mapping) is broken up into tools for voxel (3d / ok-robot style), instance mapping
+- [perception](src/stretch/perception) contains tools for perception, such as object detection and pose estimation.
+  - [perception/encoders](src/stretch/perception/encoders) contains tools for encoding vision and language features, such as the [SiglipEncoder](src/stretch/perception/encoders/siglip_encoder.py) class.
+  - [perception/captioners](src/stretch/perception/captioners) contains tools for generating captions from images, such as the [MoonbeamCaptioner](src/stretch/perception/captioners/moonbeam_captioner.py) class.
 - [agent](src/stretch/agent) is aggregate functionality, particularly robot_agent which includes lots of common tools including motion planning algorithms.
   - In particular, `agent/zmq_client.py` is specifically the robot control API, an implementation of the client in core/interfaces.py. there's another ROS client in `stretch_ros2_bridge`.
   - [agent/robot_agent.py](src/stretch/agent/robot_agent.py) is the main robot agent, which is a high-level interface to the robot. It is used in the `app` scripts.
@@ -95,3 +98,13 @@ The code is organized as follows. Inside the core package `src/stretch`:
   - [agent/operations](src/stretch/agent/operations) contains the individual operations, such as `move_to_pose.py` which moves the robot to a given pose.
 
 The [stretch_ros2_bridge](src/stretch_ros2_bridge) package is a ROS2 bridge that allows the Stretch AI code to communicate with the ROS2 ecosystem. It is a separate package that is symlinked into the `ament_ws` workspace on the robot.
+
+#### Trying individual components
+
+##### Perception
+
+You can try the captioners with:
+
+```bash
+python -m stretch.perception.captioners.moonbeam_captioner --image_path <path_to_image>
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,5 +106,10 @@ The [stretch_ros2_bridge](src/stretch_ros2_bridge) package is a ROS2 bridge that
 You can try the captioners with:
 
 ```bash
+# Moonbeam captioner
+# Gives: "A plush toy resembling a spotted animal is lying on its back on a wooden floor, with its head and front paws raised."
 python -m stretch.perception.captioners.moonbeam_captioner --image_path <path_to_image>
+
+# ViT + GPT2 captioner
+python -m stretch.perception.captioners.vit_gpt2_captioner --image_path <path_to_image>
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,4 +132,9 @@ python -m stretch.perception.captioners.blip_captioner --image_path object.png
 # Gives: "a dog laying on the floor next to a cardboard box"
 python -m stretch.perception.captioners.blip_captioner --image_path receptacle.png
 
+# Git Captioner
+# Gives: "a stuffed animal that is laying on the floor"
+python -m stretch.perception.captioners.git_captioner --image_path object.png
+# Gives: "a cardboard box on the floor"
+python -m stretch.perception.captioners.git_captioner --image_path receptacle.png
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,5 +111,6 @@ You can try the captioners with:
 python -m stretch.perception.captioners.moonbeam_captioner --image_path <path_to_image>
 
 # ViT + GPT2 captioner
+# Gives: "a cat laying on the floor next to a door"
 python -m stretch.perception.captioners.vit_gpt2_captioner --image_path <path_to_image>
 ```

--- a/docs/object.png
+++ b/docs/object.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a505b018605865e8380ebc6e7fdc85eb38bd29d5278e3c3840659a51113b2f7b
+size 45822

--- a/docs/receptacle.png
+++ b/docs/receptacle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd940b3d44fffe261b7f752c2a08cd4f092affa5638b630abb03c36802c4b9c
+size 114975

--- a/src/stretch/perception/captioners/__init__.py
+++ b/src/stretch/perception/captioners/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Hello Robot, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in the root directory
+# of this source tree.
+#
+# Some code may be adapted from other open-source works with their respective licenses. Original
+# license information maybe found below, if so.

--- a/src/stretch/perception/captioners/base_captioner.py
+++ b/src/stretch/perception/captioners/base_captioner.py
@@ -11,6 +11,7 @@ import abc
 from typing import Union
 
 from numpy import ndarray
+from PIL import Image
 from torch import Tensor
 
 
@@ -18,6 +19,6 @@ class BaseCaptioner(abc.ABC):
     """Base class for image captioning models."""
 
     @abc.abstractmethod
-    def caption_image(self, image: Union[ndarray, Tensor]):
+    def caption_image(self, image: Union[ndarray, Tensor, Image.Image]) -> str:
         """Generate a caption for an image."""
         raise NotImplementedError

--- a/src/stretch/perception/captioners/base_captioner.py
+++ b/src/stretch/perception/captioners/base_captioner.py
@@ -14,7 +14,7 @@ from numpy import ndarray
 from torch import Tensor
 
 
-class BaseImageCaptioner(abc.ABC):
+class BaseCaptioner(abc.ABC):
     """Base class for image captioning models."""
 
     @abc.abstractmethod

--- a/src/stretch/perception/captioners/base_captioner.py
+++ b/src/stretch/perception/captioners/base_captioner.py
@@ -8,26 +8,16 @@
 # license information maybe found below, if so.
 
 import abc
-
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
 from typing import Union
 
 from numpy import ndarray
 from torch import Tensor
 
 
-class BaseImageTextEncoder(abc.ABC):
-    """
-    Encodes images, encodes text, and allows comparisons between the two encoding.
-    """
+class BaseImageCaptioner(abc.ABC):
+    """Base class for image captioning models."""
 
     @abc.abstractmethod
-    def encode_image(self, image: Union[ndarray, Tensor]):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def encode_text(self, text: str):
+    def caption_image(self, image: Union[ndarray, Tensor]):
+        """Generate a caption for an image."""
         raise NotImplementedError

--- a/src/stretch/perception/captioners/base_captioner.py
+++ b/src/stretch/perception/captioners/base_captioner.py
@@ -20,5 +20,12 @@ class BaseCaptioner(abc.ABC):
 
     @abc.abstractmethod
     def caption_image(self, image: Union[ndarray, Tensor, Image.Image]) -> str:
-        """Generate a caption for an image."""
+        """Generate a caption for an image.
+
+        Args:
+            image (Union[ndarray, Tensor, Image.Image]): Image to generate caption for.
+
+        Returns:
+            str: Generated caption.
+        """
         raise NotImplementedError

--- a/src/stretch/perception/captioners/blip_captioner.py
+++ b/src/stretch/perception/captioners/blip_captioner.py
@@ -1,0 +1,101 @@
+# Copyright (c) Hello Robot, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in the root directory
+# of this source tree.
+#
+# Some code may be adapted from other open-source works with their respective licenses. Original
+# license information maybe found below, if so.
+
+from typing import Optional, Union
+
+import click
+import torch
+from numpy import ndarray
+from PIL import Image
+from torch import Tensor
+from transformers import BlipForConditionalGeneration, BlipProcessor
+
+from .base_captioner import BaseCaptioner
+
+
+class BlipCaptioner(BaseCaptioner):
+    """Image captioner using BLIP (Bootstrapping Language-Image Pre-training) model."""
+
+    def __init__(self, max_length: int = 30, num_beams: int = 4, device: Optional[str] = None):
+        """Initialize the BLIP image captioner.
+
+        Args:
+            max_length (int, optional): Maximum length of the generated caption. Defaults to 30.
+            num_beams (int, optional): Number of beams for beam search. Defaults to 4.
+            device (str, optional): Device to run the model on. Defaults to None (auto-detect).
+        """
+        super(BlipCaptioner, self).__init__()
+        self.max_length = max_length
+        self.num_beams = num_beams
+        if device is None:
+            self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        else:
+            self._device = torch.device(device)
+
+        # Create models
+        self.processor = BlipProcessor.from_pretrained("Salesforce/blip-image-captioning-base")
+        self.model = BlipForConditionalGeneration.from_pretrained(
+            "Salesforce/blip-image-captioning-base"
+        ).to(self._device)
+
+    def caption_image(self, image: Union[ndarray, Tensor, Image.Image]) -> str:
+        """Generate a caption for the given image.
+
+        Args:
+            image (Union[ndarray, Tensor, Image.Image]): The input image.
+
+        Returns:
+            str: The generated caption.
+        """
+        if isinstance(image, Image.Image):
+            pil_image = image
+        else:
+            if isinstance(image, Tensor):
+                _image = image.cpu().numpy()
+            else:
+                _image = image
+            pil_image = Image.fromarray(_image)
+
+        # Preprocess the image
+        inputs = self.processor(pil_image, return_tensors="pt").to(self._device)
+
+        # Generate caption
+        output = self.model.generate(
+            **inputs,
+            max_length=self.max_length,
+            num_beams=self.num_beams,
+            do_sample=False,
+            output_attentions=False,
+            output_hidden_states=False,
+            return_dict_in_generate=False
+        )
+
+        # Decode the output ids to text
+        caption = self.processor.decode(output[0], skip_special_tokens=True)
+
+        return caption
+
+
+@click.command()
+@click.option("--image_path", default="object.png", help="Path to image file")
+def main(image_path: str):
+    captioner = BlipCaptioner()
+
+    # Load image from file
+    image = Image.open(image_path)
+
+    # Generate caption
+    caption = captioner.caption_image(image)
+
+    # Print caption
+    print(caption)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stretch/perception/captioners/git_captioner.py
+++ b/src/stretch/perception/captioners/git_captioner.py
@@ -1,0 +1,101 @@
+# Copyright (c) Hello Robot, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in the root directory
+# of this source tree.
+#
+# Some code may be adapted from other open-source works with their respective licenses. Original
+# license information maybe found below, if so.
+
+from typing import Optional, Union
+
+import click
+import torch
+from numpy import ndarray
+from PIL import Image
+from torch import Tensor
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+from .base_captioner import BaseCaptioner
+
+
+class GitCaptioner(BaseCaptioner):
+    """Image captioner using GIT (Generative Image-to-text Transformer) model."""
+
+    def __init__(self, max_length: int = 30, num_beams: int = 4, device: Optional[str] = None):
+        """Initialize the GIT image captioner.
+
+        Args:
+            max_length (int, optional): Maximum length of the generated caption. Defaults to 30.
+            num_beams (int, optional): Number of beams for beam search. Defaults to 4.
+            device (str, optional): Device to run the model on. Defaults to None (auto-detect).
+        """
+        super(GitCaptioner, self).__init__()
+        self.max_length = max_length
+        self.num_beams = num_beams
+        if device is None:
+            self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        else:
+            self._device = torch.device(device)
+
+        # Create models
+        self.processor = AutoProcessor.from_pretrained("microsoft/git-base-coco")
+        self.model = AutoModelForCausalLM.from_pretrained("microsoft/git-base-coco").to(
+            self._device
+        )
+
+    def caption_image(self, image: Union[ndarray, Tensor, Image.Image]) -> str:
+        """Generate a caption for the given image.
+
+        Args:
+            image (Union[ndarray, Tensor, Image.Image]): The input image.
+
+        Returns:
+            str: The generated caption.
+        """
+        if isinstance(image, Image.Image):
+            pil_image = image
+        else:
+            if isinstance(image, Tensor):
+                _image = image.cpu().numpy()
+            else:
+                _image = image
+            pil_image = Image.fromarray(_image)
+
+        # Preprocess the image
+        inputs = self.processor(images=pil_image, return_tensors="pt").to(self._device)
+
+        # Generate caption
+        generated_ids = self.model.generate(
+            pixel_values=inputs.pixel_values,
+            max_length=self.max_length,
+            num_beams=self.num_beams,
+            do_sample=False,
+            output_attentions=False,
+            output_hidden_states=False,
+            return_dict_in_generate=False,
+        )
+
+        # Decode the output ids to text
+        caption = self.processor.batch_decode(generated_ids, skip_special_tokens=True)[0].strip()
+
+        return caption
+
+
+@click.command()
+@click.option("--image_path", default="object.png", help="Path to image file")
+def main(image_path: str):
+    captioner = GitCaptioner()
+
+    # Load image from file
+    image = Image.open(image_path)
+
+    # Generate caption
+    caption = captioner.caption_image(image)
+
+    # Print caption
+    print(caption)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stretch/perception/captioners/moonbeam_captioner.py
+++ b/src/stretch/perception/captioners/moonbeam_captioner.py
@@ -11,6 +11,7 @@ from typing import Union
 
 import click
 from numpy import ndarray
+from overrides import override
 from PIL import Image
 from torch import Tensor
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -30,7 +31,16 @@ class MoonbeamCaptioner(BaseCaptioner):
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)
 
-    def caption_image(self, image: Union[ndarray, Tensor, Image.Image]):
+    @override
+    def caption_image(self, image: Union[ndarray, Tensor, Image.Image]) -> str:
+        """Generate a caption for the given image.
+
+        Args:
+            image (Union[ndarray, Tensor, Image.Image]): Image to generate caption for.
+
+        Returns:
+            str: Generated caption.
+        """
         if isinstance(image, Image.Image):
             pil_image = image
         else:

--- a/src/stretch/perception/captioners/moonbeam_captioner.py
+++ b/src/stretch/perception/captioners/moonbeam_captioner.py
@@ -1,0 +1,62 @@
+# Copyright (c) Hello Robot, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in the root directory
+# of this source tree.
+#
+# Some code may be adapted from other open-source works with their respective licenses. Original
+# license information maybe found below, if so.
+
+from typing import Union
+
+import click
+from numpy import ndarray
+from PIL import Image
+from torch import Tensor
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from .base_captioner import BaseCaptioner
+
+model_id = "vikhyatk/moondream2"
+revision = "2024-07-23"
+
+
+class MoonbeamCaptioner(BaseCaptioner):
+    def __init__(self):
+        super(MoonbeamCaptioner, self).__init__()
+
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_id, trust_remote_code=True, revision=revision
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)
+
+    def caption_image(self, image: Union[ndarray, Tensor]):
+        if isinstance(image, Image.Image):
+            pil_image = image
+        else:
+            if isinstance(image, Tensor):
+                _image = image.cpu().numpy()
+            else:
+                _image = image
+            pil_image = Image.fromarray(_image)
+        enc_image = self.model.encode_image(pil_image)
+        return self.model.answer_question(enc_image, "Describe this image.", self.tokenizer)
+
+
+@click.command()
+@click.option("--image_path", default="object.png", help="Path to image file")
+def main(image_path: str):
+    captioner = MoonbeamCaptioner()
+
+    # Load image from file
+    image = Image.open(image_path)
+
+    # Generate caption
+    caption = captioner.caption_image(image)
+
+    # Print caption
+    print(caption)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stretch/perception/captioners/moonbeam_captioner.py
+++ b/src/stretch/perception/captioners/moonbeam_captioner.py
@@ -30,7 +30,7 @@ class MoonbeamCaptioner(BaseCaptioner):
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)
 
-    def caption_image(self, image: Union[ndarray, Tensor]):
+    def caption_image(self, image: Union[ndarray, Tensor, Image.Image]):
         if isinstance(image, Image.Image):
             pil_image = image
         else:

--- a/src/stretch/perception/captioners/vit_gpt2_captioner.py
+++ b/src/stretch/perception/captioners/vit_gpt2_captioner.py
@@ -1,0 +1,99 @@
+# Copyright (c) Hello Robot, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in the root directory
+# of this source tree.
+#
+# Some code may be adapted from other open-source works with their respective licenses. Original
+# license information maybe found below, if so.
+
+from typing import Optional, Union
+
+import click
+import torch
+from numpy import ndarray
+from PIL import Image
+from torch import Tensor
+from transformers import AutoTokenizer, VisionEncoderDecoderModel, ViTImageProcessor
+
+from .base_captioner import BaseCaptioner
+
+
+class VitGpt2Captioner(BaseCaptioner):
+    """Image captioner using Vision Transformer and GPT-2 model."""
+
+    def __init__(self, max_length: int = 16, num_beams: int = 4, device: Optional[str] = None):
+        """Initialize the ViT-GPT2 image captioner.
+
+        Args:
+            max_length (int, optional): Maximum length of the generated caption. Defaults to 16.
+            num_beams (int, optional): Number of beams for beam search. Defaults to 4.
+        """
+        super(VitGpt2Captioner, self).__init__()
+        self.max_length = max_length
+        self.num_beams = num_beams
+        if device is None:
+            if torch.cuda.is_available():
+                self._device = torch.device("cuda")
+            else:
+                self._device = torch.device("cpu")
+        else:
+            self._device = torch.device(device)
+
+        # Create models
+        self.model = VisionEncoderDecoderModel.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning"
+        ).to(self._device)
+        self.feature_extractor = ViTImageProcessor.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning"
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
+
+    def caption_image(self, image: Union[ndarray, Tensor]):
+        if isinstance(image, Image.Image):
+            pil_image = image
+        else:
+            if isinstance(image, Tensor):
+                _image = image.cpu().numpy()
+            else:
+                _image = image
+            pil_image = Image.fromarray(_image)
+
+        pixel_values = self.feature_extractor(images=[image], return_tensors="pt").pixel_values
+        pixel_values = pixel_values.to(self._device)
+
+        # Generate caption
+        output_ids = self.model.generate(
+            pixel_values,
+            max_length=self.max_length,
+            num_beams=self.num_beams,
+            use_cache=True,
+            no_repeat_ngram_size=3,
+            do_sample=False,
+            output_attentions=False,
+            output_hidden_states=False,
+            return_dict_in_generate=False,
+        )
+
+        # Decode the output ids to text
+        caption = self.tokenizer.decode(output_ids[0], skip_special_tokens=True)
+        return caption
+
+
+@click.command()
+@click.option("--image_path", default="object.png", help="Path to image file")
+def main(image_path: str):
+    captioner = VitGpt2Captioner()
+
+    # Load image from file
+    image = Image.open(image_path)
+
+    # Generate caption
+    caption = captioner.caption_image(image)
+
+    # Print caption
+    print(caption)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stretch/perception/captioners/vit_gpt2_captioner.py
+++ b/src/stretch/perception/captioners/vit_gpt2_captioner.py
@@ -12,6 +12,7 @@ from typing import Optional, Union
 import click
 import torch
 from numpy import ndarray
+from overrides import override
 from PIL import Image
 from torch import Tensor
 from transformers import AutoTokenizer, VisionEncoderDecoderModel, ViTImageProcessor
@@ -49,7 +50,17 @@ class VitGpt2Captioner(BaseCaptioner):
         )
         self.tokenizer = AutoTokenizer.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
 
-    def caption_image(self, image: Union[ndarray, Tensor]):
+    @override
+    def caption_image(self, image: Union[ndarray, Tensor, Image.Image]) -> str:
+        """Generate a caption for the given image.
+
+        Args:
+            image (Union[ndarray, Tensor]): Image to generate caption for.
+
+        Returns:
+            str: Generated caption.
+
+        """
         if isinstance(image, Image.Image):
             pil_image = image
         else:


### PR DESCRIPTION
## Description

For integration with OVMM code. Can be tested with:

```bash
# Moonbeam captioner
# Gives: "A plush toy resembling a spotted animal is lying on its back on a wooden floor, with its head and front paws raised."
python -m stretch.perception.captioners.moonbeam_captioner --image_path object.png
# Gives: "An open cardboard box rests on a wooden floor, with a stuffed animal lying next to it."
python -m stretch.perception.captioners.moonbeam_captioner --image_path receptacle.png

# ViT + GPT2 captioner
# Gives: "a cat laying on the floor next to a door"
python -m stretch.perception.captioners.vit_gpt2_captioner --image_path object.png
# Gives: "a box with a cat laying on top of it"
python -m stretch.perception.captioners.vit_gpt2_captioner --image_path receptacle.png

# Blip Captioner
# Gives: "a stuffed dog on the floor"
python -m stretch.perception.captioners.blip_captioner --image_path object.png
# Gives: "a dog laying on the floor next to a cardboard box"
python -m stretch.perception.captioners.blip_captioner --image_path receptacle.png
```


## Checklist

- \[ \] I have performed a self-review of my code
- \[ \] If it is a core feature, I have added thorough tests
- \[ \] I have added documentation for the changes
- \[ \] I have updated the README file if necessary
- \[ \] I have run on hardware if necessary

## Screenshots (if applicable)

Add any relevant screenshots or screen recordings to help reviewers understand the changes.

## Additional context

Add any other context or information about the pull request here.
