### PR TITLE
Remove orbslam from launch

### DIFF
--- a/src/stretch_ros2_bridge/launch/server.launch.py
+++ b/src/stretch_ros2_bridge/launch/server.launch.py
@@ -35,19 +35,9 @@ def generate_launch_description():
         )
     )
 
-    orbslam_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory("stretch_ros2_bridge"),
-                "launch/startup_stretch_orbslam.launch.py",
-            )
-        )
-    )
-
     ld = LaunchDescription(
         [
             base_slam_launch,
-            orbslam_launch,
             start_server,
         ]
     )


### PR DESCRIPTION
## Description

Remove ORB-SLAM from `server.launch` and use Hector SLAM by default.

## Checklist

- \[ \] I have performed a self-review of my code
- \[ \] If it is a core feature, I have added thorough tests
- \[ \] I have added documentation for the changes
- \[ \] I have updated the README file if necessary
- \[ \] I have run on hardware if necessary

## Screenshots (if applicable)

Add any relevant screenshots or screen recordings to help reviewers understand the changes.

## Additional context

Add any other context or information about the pull request here.
