### PR TITLE
Rerun visualize robot mesh

### DIFF
--- a/src/stretch/agent/robot_agent.py
+++ b/src/stretch/agent/robot_agent.py
@@ -395,7 +395,7 @@ class RobotAgent:
                 self.voxel_map.show(
                     orig=np.zeros(3),
                     xyt=self.robot.get_base_pose(),
-                    footprint=self.robot.get_robot_model().get_footprint(),
+                    footprint=self.robot.get_robot_model().get_(),
                     instances=self.semantic_sensor is not None,
                 )
 

--- a/src/stretch/agent/robot_agent.py
+++ b/src/stretch/agent/robot_agent.py
@@ -395,7 +395,7 @@ class RobotAgent:
                 self.voxel_map.show(
                     orig=np.zeros(3),
                     xyt=self.robot.get_base_pose(),
-                    footprint=self.robot.get_robot_model().get_(),
+                    footprint=self.robot.get_robot_model().get_footprint(),
                     instances=self.semantic_sensor is not None,
                 )
 

--- a/src/stretch/agent/zmq_client.py
+++ b/src/stretch/agent/zmq_client.py
@@ -1135,7 +1135,6 @@ class HomeRobotZmqClient(AbstractRobotClient):
         """Use the rerun server so that we can visualize what is going on as the robot takes actions in the world."""
         while not self._finish:
             self._rerun.step(self._obs, self._servo)
-            time.sleep(0.3)
 
     @property
     def is_homed(self) -> bool:

--- a/src/stretch/visualization/rerun.py
+++ b/src/stretch/visualization/rerun.py
@@ -117,45 +117,17 @@ class StretchURDFLogger(urdf_visualizer.URDFVisualizer):
                 static=True,
             )
 
-    def log_transforms(self, cfg: dict, debug: bool = False):
-        lk_cfg = {
-            "joint_wrist_yaw": cfg["wrist_yaw"],
-            "joint_wrist_pitch": cfg["wrist_pitch"],
-            "joint_wrist_roll": cfg["wrist_roll"],
-            "joint_lift": cfg["lift"],
-            "joint_arm_l0": cfg["arm"] / 4,
-            "joint_arm_l1": cfg["arm"] / 4,
-            "joint_arm_l2": cfg["arm"] / 4,
-            "joint_arm_l3": cfg["arm"] / 4,
-            "joint_head_pan": cfg["head_pan"],
-            "joint_head_tilt": cfg["head_tilt"],
-        }
-        if "gripper" in cfg.keys():
-            lk_cfg["joint_gripper_finger_left"] = cfg["gripper"]
-            lk_cfg["joint_gripper_finger_right"] = cfg["gripper"]
-        tms = self.get_tri_meshes(cfg=lk_cfg, use_collision=False)
-        self.link_poses = tms["pose"]
-        self.link_names = tms["link"]
-        for link in self.link_names:
-            idx = self.link_names.index(link)
-            rr.set_time_seconds("realtime", time.time())
-            rr.log(
-                f"world/robot/mesh/{link}",
-                rr.Transform3D(
-                    translation=self.link_poses[idx][:3, 3],
-                    mat3x3=self.link_poses[idx][:3, :3],
-                    axis_length=0.3,
-                ),
-                static=False,
-            )
-
-    def log_robot_mesh(self, cfg: dict, use_collision: bool = True, debug: bool = False):
+    def log_transforms(self, obs, debug: bool = False):
         """
-        Log robot mesh using joint configuration data
+        Log robot mesh using urdf visualizer to rerun
         Args:
-            cfg (dict): Joint configuration
+            obs (dict): Observation dataclass
             use_collision (bool): use collision mesh
         """
+        state = obs["joint"]
+        cfg = {}
+        for k in HelloStretchIdx.name_to_idx:
+            cfg[k] = state[HelloStretchIdx.name_to_idx[k]]
         lk_cfg = {
             "joint_wrist_yaw": cfg["wrist_yaw"],
             "joint_wrist_pitch": cfg["wrist_pitch"],
@@ -172,49 +144,39 @@ class StretchURDFLogger(urdf_visualizer.URDFVisualizer):
             lk_cfg["joint_gripper_finger_left"] = cfg["gripper"]
             lk_cfg["joint_gripper_finger_right"] = cfg["gripper"]
         t0 = timeit.default_timer()
-        mesh = self.get_combined_robot_mesh(cfg=lk_cfg, use_collision=use_collision)
+        tms = self.get_tri_meshes(cfg=lk_cfg, use_collision=False)
         t1 = timeit.default_timer()
+        self.link_poses = tms["pose"]
+        self.link_names = tms["link"]
+        for link in self.link_names:
+            idx = self.link_names.index(link)
+            rr.set_time_seconds("realtime", time.time())
+            rr.log(
+                f"world/robot/mesh/{link}",
+                rr.Transform3D(
+                    translation=self.link_poses[idx][:3, 3],
+                    mat3x3=self.link_poses[idx][:3, :3],
+                    axis_length=0.3,
+                ),
+                static=False,
+            )
+        t2 = timeit.default_timer()
         if debug:
-            print(f"Time to get mesh: {1000*(t1 - t1)} ms")
-        # breakpoint()
-        rr.set_time_seconds("realtime", time.time())
-        rr.log(
-            "world/robot/mesh",
-            rr.Mesh3D(
-                vertex_positions=mesh.vertices,
-                triangle_indices=mesh.faces,
-                vertex_normals=mesh.vertex_normals,
-                # vertex_colors=vertex_colors,
-                # albedo_texture=albedo_texture,
-                # vertex_texcoords=vertex_texcoords,
-            ),
-            timeless=True,
-        )
-        t2 = 1000 * (timeit.default_timer() - t1)
-        if debug:
-            print(f"Time to rr log mesh: {t2}")
-            print(f"Total time to log mesh: {1000*(timeit.default_timer() - t0)} ms")
-
-    def log(self, obs, use_collision: bool = True, debug: bool = False):
-        """
-        Log robot mesh using urdf visualizer to rerun
-        Args:
-            obs (dict): Observation dataclass
-            use_collision (bool): use collision mesh
-        """
-        state = obs["joint"]
-        cfg = {}
-        for k in HelloStretchIdx.name_to_idx:
-            cfg[k] = state[HelloStretchIdx.name_to_idx[k]]
-        # breakpoint()
-        # self.log_robot_mesh(cfg=cfg, use_collision=use_collision)
-        self.log_transforms(cfg=cfg, debug=debug)
+            print("Time to get tri meshes (ms): ", 1000 * (t1 - t0))
+            print("Time to log robot transforms (ms): ", 1000 * (t2 - t1))
+            print("Total time to log robot transforms (ms): ", 1000 * (t2 - t0))
 
 
 class RerunVsualizer:
-    def __init__(self, display_robot_mesh: bool = True, open_browser: bool = True):
+    def __init__(
+        self,
+        display_robot_mesh: bool = True,
+        open_browser: bool = True,
+        server_memory_limit: str = "4GB",
+        collapse_panels: bool = True,
+    ):
         rr.init("Stretch_robot", spawn=False)
-        rr.serve(open_browser=open_browser, server_memory_limit="2GB")
+        rr.serve(open_browser=open_browser, server_memory_limit=server_memory_limit)
 
         self.display_robot_mesh = display_robot_mesh
 
@@ -238,23 +200,26 @@ class RerunVsualizer:
         )
 
         self.bbox_colors_memory = {}
-        self.step_delay_s = 1 / 15
-        self.setup_blueprint()
+        self.step_delay_s = 0.3
+        self.setup_blueprint(collapse_panels)
 
-    def setup_blueprint(self):
-        """Setup the blueprint for the visualizer"""
-        my_blueprint = rrb.Blueprint(
-            rrb.Horizontal(
-                rrb.Spatial3DView(name="3D View", origin="world"),
-                rrb.Vertical(
-                    rrb.Spatial2DView(name="head_rgb", origin="/world/head_camera"),
-                    rrb.Spatial2DView(name="ee_rgb", origin="/world/ee_camera"),
-                ),
-                rrb.TimePanel(state=True),
-                rrb.SelectionPanel(state=True),
-                rrb.BlueprintPanel(state=True),
+    def setup_blueprint(self, collapse_panels: bool):
+        """Setup the blueprint for the visualizer
+        Args:
+            collapse_panels (bool): fully hides the blueprint/selection panels,
+                                    and shows the simplified time panel
+        """
+        main = rrb.Horizontal(
+            rrb.Spatial3DView(name="3D View", origin="world"),
+            rrb.Vertical(
+                rrb.Spatial2DView(name="head_rgb", origin="/world/head_camera"),
+                rrb.Spatial2DView(name="ee_rgb", origin="/world/ee_camera"),
             ),
-            collapse_panels=True,
+            column_shares=[3, 1],
+        )
+        my_blueprint = rrb.Blueprint(
+            rrb.Vertical(main, rrb.TimePanel(state=True)),
+            collapse_panels=collapse_panels,
         )
         rr.send_blueprint(my_blueprint)
 
@@ -338,10 +303,10 @@ class RerunVsualizer:
         for k in HelloStretchIdx.name_to_idx:
             rr.log(f"robot_state/joint_pose/{k}", rr.Scalar(state[HelloStretchIdx.name_to_idx[k]]))
 
-    def log_robot_mesh(self, obs, use_collision=True):
+    def log_robot_transforms(self, obs):
         """
-        Log robot mesh using urdf visualizer"""
-        self.urdf_logger.log(obs, use_collision=use_collision)
+        Log robot mesh transforms using urdf visualizer"""
+        self.urdf_logger.log_transforms(obs)
 
     def update_voxel_map(
         self,
@@ -467,7 +432,7 @@ class RerunVsualizer:
         rr.set_time_seconds("realtime", ts)
         rr.log("world/xyt_goal/blob", rr.Points3D([0, 0, 0], colors=[0, 255, 0, 50], radii=0.1))
         rr.log(
-            "world/xyt_goal",
+            "world/xyt_goal/blob",
             rr.Transform3D(
                 translation=[goal[0], goal[1], 0],
                 rotation=rr.RotationAxisAngle(axis=[0, 0, 1], radians=goal[2]),
@@ -483,6 +448,7 @@ class RerunVsualizer:
         if obs and servo:
             rr.set_time_seconds("realtime", time.time())
             try:
+                t0 = timeit.default_timer()
                 self.log_robot_xyt(obs)
                 self.log_head_camera(obs)
                 self.log_ee_frame(obs)
@@ -490,7 +456,11 @@ class RerunVsualizer:
                 self.log_robot_state(obs)
 
                 if self.display_robot_mesh:
-                    self.log_robot_mesh(obs)
+                    self.log_robot_transforms(obs)
+                t1 = timeit.default_timer()
+                sleep_time = self.step_delay_s - (t1 - t0)
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
 
             except Exception as e:
                 print(e)

--- a/src/stretch/visualization/rerun.py
+++ b/src/stretch/visualization/rerun.py
@@ -102,7 +102,14 @@ class StretchURDFLogger(urdf_visualizer.URDFVisualizer):
     link_names = []
     link_poses = []
 
-    def load_robot_mesh(self, cfg: dict = None, use_collision: bool = True, debug: bool = False):
+    def load_robot_mesh(self, cfg: dict = None, use_collision: bool = False):
+        """
+        Load robot mesh using urdf visualizer to rerun
+        This is to be run once at the beginning of the rerun
+        Args:
+            cfg (dict): Configuration of the robot
+            use_collision (bool): use collision mesh
+        """
         trimesh_list = self.get_tri_meshes(cfg=cfg, use_collision=use_collision)
         self.link_names = trimesh_list["link"]
         self.link_poses = trimesh_list["pose"]

--- a/src/stretch/visualization/rerun.py
+++ b/src/stretch/visualization/rerun.py
@@ -156,7 +156,7 @@ class StretchURDFLogger(urdf_visualizer.URDFVisualizer):
                 rr.Transform3D(
                     translation=self.link_poses[idx][:3, 3],
                     mat3x3=self.link_poses[idx][:3, :3],
-                    axis_length=0.3,
+                    axis_length=0.0,
                 ),
                 static=False,
             )
@@ -235,7 +235,7 @@ class RerunVsualizer:
             rr.Pinhole(
                 resolution=[obs["rgb"].shape[1], obs["rgb"].shape[0]],
                 image_from_camera=obs["camera_K"],
-                image_plane_distance=0.25,
+                image_plane_distance=0.15,
             ),
         )
 
@@ -246,13 +246,12 @@ class RerunVsualizer:
         theta = obs["compass"]
         rb_arrow = rr.Arrows3D(
             origins=[0, 0, 0],
-            vectors=[0.5, 0, 0],
+            vectors=[0.4, 0, 0],
             radii=0.02,
             labels="robot",
             colors=[255, 0, 0, 255],
         )
         rr.log("world/robot/arrow", rb_arrow)
-        rr.log("world/robot/blob", rr.Points3D([0, 0, 0], colors=[255, 0, 0, 255], radii=0.13))
         rr.log(
             "world/robot",
             rr.Transform3D(
@@ -292,7 +291,7 @@ class RerunVsualizer:
             rr.Pinhole(
                 resolution=[servo.ee_rgb.shape[1], servo.ee_rgb.shape[0]],
                 image_from_camera=servo.ee_camera_K,
-                image_plane_distance=0.25,
+                image_plane_distance=0.15,
             ),
         )
 
@@ -430,18 +429,18 @@ class RerunVsualizer:
         """
         ts = time.time()
         rr.set_time_seconds("realtime", ts)
-        rr.log("world/xyt_goal/blob", rr.Points3D([0, 0, 0], colors=[0, 255, 0, 50], radii=0.1))
+        rr.log("world/xyt_goal", rr.Points3D([0, 0, 0], colors=[0, 255, 0, 50], radii=0.1))
         rr.log(
-            "world/xyt_goal/blob",
+            "world/xyt_goal",
             rr.Transform3D(
                 translation=[goal[0], goal[1], 0],
                 rotation=rr.RotationAxisAngle(axis=[0, 0, 1], radians=goal[2]),
                 axis_length=0.5,
             ),
         )
-        rr.set_time_seconds("realtime", ts + timeout)
-        rr.log("world/xyt_goal", rr.Clear(recursive=True))
-        rr.set_time_seconds("realtime", ts)
+        # rr.set_time_seconds("realtime", ts + timeout)
+        # rr.log("world/xyt_goal", rr.Clear(recursive=True))
+        # rr.set_time_seconds("realtime", ts)
 
     def step(self, obs, servo):
         """Log all the data"""

--- a/src/stretch/visualization/rerun.py
+++ b/src/stretch/visualization/rerun.py
@@ -182,6 +182,13 @@ class RerunVsualizer:
         server_memory_limit: str = "4GB",
         collapse_panels: bool = True,
     ):
+        """Rerun visualizer class
+        Args:
+            display_robot_mesh (bool): Display robot mesh
+            open_browser (bool): Open browser at start
+            server_memory_limit (str): Server memory limit E.g. 2GB or 20%
+            collapse_panels (bool): Set to false to have customizable rerun panels
+        """
         rr.init("Stretch_robot", spawn=False)
         rr.serve(open_browser=open_browser, server_memory_limit=server_memory_limit)
 

--- a/src/stretch/visualization/urdf_visualizer.py
+++ b/src/stretch/visualization/urdf_visualizer.py
@@ -51,8 +51,9 @@ def get_absolute_path_stretch_urdf(urdf_file_path, mesh_files_directory_path) ->
 
 
 class URDFVisualizer:
-    """The `show` method in this class is modified from the
-    original implementation of `urdf_loader.URDF.show`.
+    """
+    URDF wrapper class to get trimesh objects, link poses and FK transformations
+    using urchin.urdf_loader
     """
 
     abs_urdf_file_path = get_absolute_path_stretch_urdf(urdf_file_path, mesh_files_directory_path)

--- a/src/stretch/visualization/urdf_visualizer.py
+++ b/src/stretch/visualization/urdf_visualizer.py
@@ -11,6 +11,7 @@
 
 import importlib.resources as importlib_resources
 import re
+import timeit
 
 import numpy as np
 import urchin as urdf_loader
@@ -59,7 +60,9 @@ class URDFVisualizer:
     def __init__(self, urdf_file: str = abs_urdf_file_path):
         self.urdf = urdf_loader.URDF.load(urdf_file)
 
-    def get_tri_meshes(self, cfg: dict = None, use_collision: bool = True) -> list:
+    def get_tri_meshes(
+        self, cfg: dict = None, use_collision: bool = True, debug: bool = False
+    ) -> list:
         """
         Get list of trimesh objects, pose and link names of the robot with the given configuration
         Args:
@@ -68,10 +71,12 @@ class URDFVisualizer:
         Returns:
             list: List of trimesh objects, pose and link names of the robot with the given configuration
         """
+        t0 = timeit.default_timer()
         if use_collision:
             fk = self.urdf.collision_trimesh_fk(cfg=cfg)
         else:
             fk = self.urdf.visual_trimesh_fk(cfg=cfg)
+        t1 = timeit.default_timer()
         t_meshes = {"mesh": [], "pose": [], "link": []}
         for tm in fk:
             pose = fk[tm]
@@ -82,6 +87,10 @@ class URDFVisualizer:
             t_meshes["link"].append(
                 tm.metadata["file_name"][:-4] if "file_name" in tm.metadata.keys() else None
             )
+        t2 = timeit.default_timer()
+        if debug:
+            print(f"[get_trimeshes method] Time to compute FK (ms): {1000 * (t1 - t0)}")
+            print(f"[get_trimeshes method] Time to get meshes list (ms): {1000 * (t2 - t1)}")
         return t_meshes
 
     def get_combined_robot_mesh(self, cfg: dict = None, use_collision: bool = True) -> Trimesh:


### PR DESCRIPTION
## Description
This PR modifies the rerun to visualize the actual robot mesh in realtime and adds some more improvements.
Additionally now the Rerun visualizer class has the option `collapse_panels` set to `true` by default. This can be set to false which shows all the customizable panels and debug info which is very useful during developments.

## Checklist

- \[ \] I have performed a self-review of my code
- \[ \] If it is a core feature, I have added thorough tests
- \[ \] I have added documentation for the changes
- \[ \] I have updated the README file if necessary
- \[ \] I have run on hardware if necessary

## Screenshots (if applicable)
![Screenshot from 2024-09-19 19-36-53](https://github.com/user-attachments/assets/2dc119cb-6fd2-4b5c-8913-a48bc762d44d)



## Additional context

Add any other context or information about the pull request here.
