### PR TITLE
update docker script: any user should be supported on robot, not just hello-robot

### DIFF
--- a/scripts/run_stretch_ai_ros2_bridge_server.sh
+++ b/scripts/run_stretch_ai_ros2_bridge_server.sh
@@ -17,8 +17,8 @@ sudo docker run -it \
     --net=host \
     --privileged \
     -v /dev:/dev \
-    -v /home/$USER/stretch_user:/home/hello-robot/stretch_user \
+    -v /home/$USER/stretch_user:/home/hello-robot/stretch_user_copy \
     -v /home/$USER/ament_ws/install/stretch_description/share/stretch_description/urdf:/home/hello-robot/stretch_description/share/stretch_description/urdf \
     -e HELLO_FLEET_ID=$HELLO_FLEET_ID \
     hellorobotinc/stretch-ai-ros2-bridge:$VERSION \
-    bash -c "source /home/hello-robot/.bashrc; export HELLO_FLEET_ID=$HELLO_FLEET_ID; ros2 launch stretch_ros2_bridge server.launch.py"
+    bash -c "source /home/hello-robot/.bashrc; cp -r /home/hello-robot/stretch_user_copy/* /home/hello-robot/stretch_user/*; export HELLO_FLEET_ID=$HELLO_FLEET_ID; ros2 launch stretch_ros2_bridge server.launch.py"

--- a/scripts/run_stretch_ai_ros2_bridge_server.sh
+++ b/scripts/run_stretch_ai_ros2_bridge_server.sh
@@ -21,4 +21,4 @@ sudo docker run -it \
     -v /home/$USER/ament_ws/install/stretch_description/share/stretch_description/urdf:/home/hello-robot/stretch_description/share/stretch_description/urdf \
     -e HELLO_FLEET_ID=$HELLO_FLEET_ID \
     hellorobotinc/stretch-ai-ros2-bridge:$VERSION \
-    bash -c "source /home/hello-robot/.bashrc; cp -r /home/hello-robot/stretch_user_copy/* /home/hello-robot/stretch_user/*; export HELLO_FLEET_ID=$HELLO_FLEET_ID; ros2 launch stretch_ros2_bridge server.launch.py"
+    bash -c "source /home/hello-robot/.bashrc; cp -rf /home/hello-robot/stretch_user_copy/* /home/hello-robot/stretch_user/*; export HELLO_FLEET_ID=$HELLO_FLEET_ID; ros2 launch stretch_ros2_bridge server.launch.py"

--- a/scripts/run_stretch_ai_ros2_bridge_server.sh
+++ b/scripts/run_stretch_ai_ros2_bridge_server.sh
@@ -21,4 +21,4 @@ sudo docker run -it \
     -v /home/$USER/ament_ws/install/stretch_description/share/stretch_description/urdf:/home/hello-robot/stretch_description/share/stretch_description/urdf \
     -e HELLO_FLEET_ID=$HELLO_FLEET_ID \
     hellorobotinc/stretch-ai-ros2-bridge:$VERSION \
-    bash -c "source /home/hello-robot/.bashrc; cp -rf /home/hello-robot/stretch_user_copy/* /home/hello-robot/stretch_user/*; export HELLO_FLEET_ID=$HELLO_FLEET_ID; ros2 launch stretch_ros2_bridge server.launch.py"
+    bash -c "source /home/hello-robot/.bashrc; cp -rf /home/hello-robot/stretch_user_copy/* /home/hello-robot/stretch_user; export HELLO_FLEET_ID=$HELLO_FLEET_ID; ros2 launch stretch_ros2_bridge server.launch.py"

--- a/scripts/run_stretch_ai_ros2_bridge_server.sh
+++ b/scripts/run_stretch_ai_ros2_bridge_server.sh
@@ -17,8 +17,8 @@ sudo docker run -it \
     --net=host \
     --privileged \
     -v /dev:/dev \
-    -v /home/hello-robot/stretch_user:/home/hello-robot/stretch_user \
-    -v /home/hello-robot/ament_ws/install/stretch_description/share/stretch_description/urdf:/home/hello-robot/stretch_description/share/stretch_description/urdf \
+    -v /home/$USER/stretch_user:/home/hello-robot/stretch_user \
+    -v /home/$USER/ament_ws/install/stretch_description/share/stretch_description/urdf:/home/hello-robot/stretch_description/share/stretch_description/urdf \
     -e HELLO_FLEET_ID=$HELLO_FLEET_ID \
     hellorobotinc/stretch-ai-ros2-bridge:$VERSION \
     bash -c "source /home/hello-robot/.bashrc; export HELLO_FLEET_ID=$HELLO_FLEET_ID; ros2 launch stretch_ros2_bridge server.launch.py"


### PR DESCRIPTION
## Description

Saving logs was causing trouble in the docker image if it was a different user from hello-robot. To fix this, copy the stretch_user directory on startup. All logs will be lost. 

## Checklist

- \[ \] I have performed a self-review of my code
- \[ \] If it is a core feature, I have added thorough tests
- \[ \] I have added documentation for the changes
- \[ \] I have updated the README file if necessary
- \[ \] I have run on hardware if necessary

## Screenshots (if applicable)

Add any relevant screenshots or screen recordings to help reviewers understand the changes.

## Additional context

Add any other context or information about the pull request here.
