### PR TITLE
Use HTTPS instead of SSH to clone

### DIFF
--- a/docs/start_with_docker_plus_virtenv.md
+++ b/docs/start_with_docker_plus_virtenv.md
@@ -143,7 +143,7 @@ git lfs install
 
 # Clone the repository
 # Do not forget the --recursive flag to clone submodules
-git clone git@github.com:hello-robot/stretch_ai.git --recursive
+git clone https://github.com/hello-robot/stretch_ai.git --recursive
 
 # Install system dependencies
 # Pyaudio will fail if these are not installed


### PR DESCRIPTION
## Description

Quick patch to use HTTPS instead of SSH to clone, in case the user hasn't set up SSH for git.

## Checklist

- \[x\] I have performed a self-review of my code
- \[x\] If it is a core feature, I have added thorough tests
- \[x\] I have added documentation for the changes
- \[x\] I have updated the README file if necessary
- \[x\] I have run on hardware if necessary
