### PR TITLE
Add deepseek support

### DIFF
--- a/src/stretch/llms/__init__.py
+++ b/src/stretch/llms/__init__.py
@@ -17,7 +17,7 @@ from .prompts.object_manip_nav_prompt import ObjectManipNavPromptBuilder
 from .prompts.ok_robot_prompt import OkRobotPromptBuilder
 from .prompts.pickup_prompt import PickupPromptBuilder
 from .prompts.simple_prompt import SimpleStretchPromptBuilder
-from .qwen_client import Qwen25Client
+from .qwen_client import Qwen25Client, qwen_sizes, qwen_fine_tuning_options
 
 # This is a list of all the modules that are imported when you use the import * syntax.
 # The __all__ variable is used to define what symbols get exported when from a module when you use the import * syntax.
@@ -45,8 +45,8 @@ llms = {
 
 # Add all the various Qwen25 variants
 qwen_variants = []
-for model_size in ["0.5B", "1.5B", "3B", "7B", "14B", "32B", "72B"]:
-    for fine_tuning in ["Instruct", "Coder", "Math"]:
+for model_size in qwen_sizes:
+    for fine_tuning in qwen_fine_tuning_options:
         qwen_variants.append(f"qwen25-{model_size}-{fine_tuning}")
         llms.update({variant: Qwen25Client for variant in qwen_variants})
 

--- a/src/stretch/llms/qwen_client.py
+++ b/src/stretch/llms/qwen_client.py
@@ -32,7 +32,7 @@ class Qwen25Client(AbstractLLMClient):
         super().__init__(prompt, prompt_kwargs)
         assert device in ["cuda", "mps"], f"Invalid device: {device}"
         assert model_size in qwen_sizes, f"Invalid model size: {model_size}"
-        assert fine_tuning in qwen_fine_tuning_options f"Invalid fine-tuning: {fine_tuning}"
+        assert fine_tuning in qwen_fine_tuning_options, f"Invalid fine-tuning: {fine_tuning}"
 
         self.max_tokens = max_tokens
         if fine_tuning == "Deepseek":

--- a/src/stretch/llms/qwen_client.py
+++ b/src/stretch/llms/qwen_client.py
@@ -16,6 +16,9 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
 from stretch.llms.base import AbstractLLMClient, AbstractPromptBuilder
 
 
+qwen_fine_tuning_options = ["Instruct", "Coder", "Math", "Deepseek"]
+qwen_sizes = ["0.5B", "1.5B", "3B", "7B", "14B", "32B", "72B"]
+
 class Qwen25Client(AbstractLLMClient):
     def __init__(
         self,
@@ -28,19 +31,14 @@ class Qwen25Client(AbstractLLMClient):
     ):
         super().__init__(prompt, prompt_kwargs)
         assert device in ["cuda", "mps"], f"Invalid device: {device}"
-        assert model_size in [
-            "0.5B",
-            "1.5B",
-            "3B",
-            "7B",
-            "14B",
-            "32B",
-            "72B",
-        ], f"Invalid model size: {model_size}"
-        assert fine_tuning in ["Instruct", "Coder", "Math"], f"Invalid fine-tuning: {fine_tuning}"
+        assert model_size in qwen_sizes, f"Invalid model size: {model_size}"
+        assert fine_tuning in qwen_fine_tuning_options f"Invalid fine-tuning: {fine_tuning}"
 
         self.max_tokens = max_tokens
-        model_name = f"Qwen/Qwen2.5-{model_size}-{fine_tuning}"
+        if fine_tuning == "Deepseek":
+            model_name = f"deepseek-ai/DeepSeek-R1-Distill-Qwen-{size}"
+        else:
+            model_name = f"Qwen/Qwen2.5-{model_size}-{fine_tuning}"
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
## Description

Adds deepseek as a model option under qwen. Example usage:

```
 python -m stretch.app.chat --llm qwen25-3B-Deepseek 
 ```

## Checklist

- \[ \] I have performed a self-review of my code
- \[ \] If it is a core feature, I have added thorough tests
- \[ \] I have added documentation for the changes
- \[ \] I have updated the README file if necessary
- \[ \] I have run on hardware if necessary

## Screenshots (if applicable)

Add any relevant screenshots or screen recordings to help reviewers understand the changes.

## Additional context

Add any other context or information about the pull request here.
