### PR TITLE
Fix typo in docs/apps.md: 'caneras' → 'cameras'

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -68,7 +68,7 @@ python -m stretch.app.print_joint_states --joint arm
 
 #### Visualization and Streaming Video
 
-Visualize output from the caneras and other sensors on the robot. This will open multiple windows with wrist camera and both low and high resolution head camera feeds.
+Visualize output from the cameras and other sensors on the robot. This will open multiple windows with wrist camera and both low and high resolution head camera feeds.
 
 ```bash
 python -m stretch.app.view_images --robot_ip $ROBOT_IP


### PR DESCRIPTION
## Description

Fixes a typo in `docs/apps.md`: corrected "caneras" to "cameras".

## Checklist

- \[x\] I have performed a self-review of my code
- \[ \] If it is a core feature, I have added thorough tests
- \[ \] I have added documentation for the changes
- \[ \] I have updated the README file if necessary
- \[ \] I have run on hardware if necessary

## Screenshots (if applicable)

N/A

## Additional context

This is a minor documentation fix, no functional changes.
