### PR TITLE
Fix/docker setup update

### DIFF
--- a/docker/Dockerfile.ros2_patch
+++ b/docker/Dockerfile.ros2_patch
@@ -1,0 +1,73 @@
+FROM hellorobotinc/stretch-ai-ros2-bridge:latest
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Refresh ROS archive key before apt update
+RUN mkdir -p /usr/share/keyrings && \
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+      -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+# Disable RealSense apt repo (broken GPG key breaks apt-get update).
+# Safe: we are not installing/updating RealSense here; existing packages remain.
+RUN find /etc/apt/sources.list.d -type f \( -name '*realsense*' -o -name '*librealsense*' \) -delete || true
+
+# Install Terminator + dbus-launch support
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends terminator dbus-x11 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Make sure the runtime user has a real shell
+RUN usermod -s /bin/bash hello-robot
+
+# Remove baked robot identity from the image so compose/runtime can provide it
+RUN sed -i '/HELLO_FLEET_ID/d' /home/hello-robot/.bashrc
+
+# Pin numpy to a cmeel-compatible version
+RUN printf "numpy==1.24.4\n" > /tmp/constraints.txt
+
+# Upgrade pip
+RUN python3 -m pip install --upgrade pip
+
+# Remove old user-site Stretch packages
+RUN su - hello-robot -c "python3 -m pip uninstall -y \
+    hello-robot-stretch-body \
+    hello-robot-stretch-body-tools \
+    hello-robot-stretch-urdf \
+    hello-robot-stretch-factory" || true
+
+# Reinstall latest Stretch Python packages into the runtime user environment
+RUN su - hello-robot -c "python3 -m pip install --upgrade --no-cache-dir --no-deps \
+    hello-robot-stretch-body \
+    hello-robot-stretch-body-tools \
+    hello-robot-stretch-urdf \
+    hello-robot-stretch-factory"
+
+COPY fix_python_user_site.sh /tmp/fix_python_user_site.sh
+
+RUN chmod +x /tmp/fix_python_user_site.sh && \
+    su - hello-robot -c "/tmp/fix_python_user_site.sh"
+
+# Update stretch_ros2 and rebuild workspace
+RUN su - hello-robot -c "bash -lc ' \
+    cd ~/ament_ws/src/stretch_ros2 && \
+    git pull && \
+    cd ~/ament_ws && \
+    source /opt/ros/humble/setup.bash && \
+    colcon build && \
+    source install/setup.bash \
+'"
+
+# Sanity checks at build time
+RUN su - hello-robot -c "python3 -m pip show \
+    hello-robot-stretch-body \
+    hello-robot-stretch-body-tools \
+    hello-robot-stretch-urdf \
+    hello-robot-stretch-factory"
+
+RUN su - hello-robot -c "python3 -c 'import stretch_body; print(stretch_body.__file__)'"
+
+USER hello-robot
+
+# Docker image version 0.4.0 
+

--- a/docker/Dockerfile.ros2_patch
+++ b/docker/Dockerfile.ros2_patch
@@ -1,4 +1,4 @@
-FROM hellorobotinc/stretch-ai-ros2-bridge:latest
+FROM hellorobotinc/stretch-install-image:ros2
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
@@ -43,7 +43,7 @@ RUN su - hello-robot -c "python3 -m pip install --upgrade --no-cache-dir --no-de
     hello-robot-stretch-urdf \
     hello-robot-stretch-factory"
 
-COPY fix_python_user_site.sh /tmp/fix_python_user_site.sh
+COPY docker/fix_python_user_site.sh /tmp/fix_python_user_site.sh
 
 RUN chmod +x /tmp/fix_python_user_site.sh && \
     su - hello-robot -c "/tmp/fix_python_user_site.sh"

--- a/docker/build-robot-docker.sh
+++ b/docker/build-robot-docker.sh
@@ -33,7 +33,7 @@ if [ "$SKIP_ASKING" == "false" ]; then
     fi
 fi
 # Build the docker image with the current tag.
-docker build -t hellorobotinc/stretch-ai-ros2-bridge:$VERSION . -f docker/Dockerfile.ros2 --no-cache
+docker build -t hellorobotinc/stretch-ai-ros2-bridge:$VERSION . -f docker/Dockerfile.ros2_patch --no-cache
 docker push hellorobotinc/stretch-ai-ros2-bridge:$VERSION
 docker tag hellorobotinc/stretch-ai-ros2-bridge:$VERSION hellorobotinc/stretch-ai-ros2-bridge:latest
 docker push hellorobotinc/stretch-ai-ros2-bridge:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  stretch-ai:
+    # cd repos/stretch_ai/
+    # xhost + local:root
+    # export VERSION=$(python3 ~/repos/stretch_ai/src/stretch/version.py)
+    image: hellorobotinc/stretch-ai-ros2-bridge:latest
+    container_name: stretch-ai-ros2-bridge
+    network_mode: host
+    privileged: true
+    stdin_open: true
+    tty: true
+
+    environment:
+      DISPLAY: ${DISPLAY}
+      HELLO_FLEET_ID: ${HELLO_FLEET_ID}
+
+    devices:
+      - /dev/snd:/dev/snd
+
+    volumes:
+      - /dev:/dev
+      - /run/udev:/run/udev:ro
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /run/dbus:/run/dbus:rw
+      - /dev/shm:/dev/shm
+      - /home/${USER}/stretch_user:/home/hello-robot/stretch_user_copy
+      - /home/${USER}/ament_ws/install/stretch_description/share/stretch_description/urdf:/home/hello-robot/stretch_description/share/stretch_description/urdf
+      # make sure to match your local path to stretch_ai for creating this volume
+      # change this path: /home/${USER}/repos/stretch_ai to your local path
+      #- /home/${USER}/repos/stretch_ai:/home/hello-robot/stretch_ai:rw
+
+    group_add:
+      - audio
+
+    command:
+      - bash
+      - -lc
+      - |
+          cp -rf /home/hello-robot/stretch_user_copy/* /home/hello-robot/stretch_user
+          source /home/hello-robot/.bashrc
+          dbus-launch terminator -u --title="Task Container 0.4.0"

--- a/docker/fix_python_user_site.sh
+++ b/docker/fix_python_user_site.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+SITE_PKGS="/home/hello-robot/.local/lib/python3.10/site-packages"
+
+rm -rf "$SITE_PKGS"/setuptools*
+rm -rf "$SITE_PKGS"/_distutils_hack
+rm -f  "$SITE_PKGS"/distutils-precedence.pth
+rm -f  "$SITE_PKGS"/pathlib.py
+rm -rf "$SITE_PKGS"/pathlib-*.dist-info
+rm -rf "$SITE_PKGS"/pkg_resources
+rm -rf "$SITE_PKGS"/packaging*
+rm -rf "$SITE_PKGS"/setuptools_scm*
+
+python3 -c "import setuptools, stretch_body; print('setuptools', setuptools.__version__, setuptools.__file__); print('stretch_body', stretch_body.__file__)"

--- a/docs/start_with_docker_plus_virtenv.md
+++ b/docs/start_with_docker_plus_virtenv.md
@@ -122,11 +122,8 @@ Follow the install instructions for mamba [here](https://github.com/conda-forge/
 ```bash
 curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 bash Miniforge3-$(uname)-$(uname -m).sh
+source ~/.bashrc 
 ```
-
-Make sure to run `mamba init` and restart your terminal before proceeding.
-
-Run `mamba activate` if not already in the base environment
 
 Then, run:
 

--- a/scripts/run_stretch_ai_ros2_bridge_server.sh
+++ b/scripts/run_stretch_ai_ros2_bridge_server.sh
@@ -49,9 +49,6 @@ parent_dir="$(dirname "$script_dir")"
 
 # echo "Reading version from $parent_dir/src/stretch/version.py"
 VERSION=`python3 $parent_dir/src/stretch/version.py`
-echo "Source version: $VERSION"
-
-VERSION="latest"
 echo "Docker image version: $VERSION"
 
 # sudo chown -R $USER:$USER /home/$USER/stretch_user
@@ -101,3 +98,4 @@ run_docker_command run -it --rm \
     -e HELLO_FLEET_ID=$HELLO_FLEET_ID \
     hellorobotinc/stretch-ai-ros2-bridge:$VERSION \
     bash -c "source /home/hello-robot/.bashrc; cp -rf /home/hello-robot/stretch_user_copy/* /home/hello-robot/stretch_user; export HELLO_FLEET_ID=$HELLO_FLEET_ID; $launch_command"
+    

--- a/src/stretch/version.py
+++ b/src/stretch/version.py
@@ -12,7 +12,7 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 
 __stretchpy_protocol__ = "spp0"
 


### PR DESCRIPTION
## Summary
Update Dockerfile and align image to `0.4.0`, primarily updating Stretch Python packages to the latest versions.

## Changes
- Update Stretch Python packages 
- Refresh ROS apt key
- Remove broken RealSense apt source
- Remove baked `HELLO_FLEET_ID`
- Add user-site Python cleanup step
- Update stretch_ros2 and rebuild
- Push updated image to Docker Hub


This ensures the container uses the latest Stretch packages and avoid issues from stale Python environments or broken apt sources.

