### PR TITLE
Add CLI option to select TTS output target (robot or pc)

### DIFF
--- a/src/stretch/agent/task/pickup/pickup_executor.py
+++ b/src/stretch/agent/task/pickup/pickup_executor.py
@@ -22,6 +22,7 @@ from stretch.agent.task.pickup.place_task import PlaceOnReceptacleTask
 from stretch.core import AbstractRobotClient
 from stretch.utils.image import numpy_image_to_bytes
 from stretch.utils.logger import Logger
+from stretch.audio.text_to_speech import PiperTextToSpeech
 
 logger = Logger(__name__)
 # Default to hiding info messages
@@ -42,6 +43,7 @@ class PickupExecutor:
         dry_run: bool = False,
         available_actions: List[str] = None,
         discord_bot=None,
+        tts_target: str = "robot",
     ) -> None:
         """Initialize the executor.
 
@@ -70,6 +72,8 @@ class PickupExecutor:
         # Configuration
         self._match_method = match_method
         self._open_loop = open_loop
+        self.tts_target = tts_target
+        self.local_tts = PiperTextToSpeech() if tts_target == "pc" else None
 
     def _pickup(self, target_object: str, target_receptacle: str) -> None:
         """Create a task to pick up the object and execute it.
@@ -238,7 +242,10 @@ class PickupExecutor:
 
         if response is None or len(response) == 0:
             logger.error("No commands to execute!")
-            self.agent.robot_say("I'm sorry, I didn't understand that.")
+            if self.tts_target == "pc":
+                self.local_tts.say_async("I'm sorry, I didn't understand that.")
+            else:
+                self.agent.robot_say("I'm sorry, I didn't understand that.")
             return True
 
         logger.info("Resetting agent...")
@@ -251,16 +258,18 @@ class PickupExecutor:
             command, args = response[i]
             logger.info(f"Command: {i} {command} {args}")
             if command == "say":
-                # Use TTS to say the text
                 logger.info(f"Saying: {args}")
+
+                if isinstance(args, str) and args and args[0] == '"' and args[-1] == '"':
+                    args = args[1:-1]
+
                 if channel is not None:
-                    # obs = self.robot.get_observation()
-                    # self.discord_bot.send_message(channel=channel, message=args, content=numpy_image_to_bytes(obs.rgb))
-                    # Optionally strip quotes from args
-                    if args[0] == '"' and args[-1] == '"':
-                        args = args[1:-1]
                     self.discord_bot.send_message(channel=channel, message=args)
-                self.agent.robot_say(args)
+
+                if self.tts_target == "pc":
+                    self.local_tts.say_async(args)
+                else:
+                    self.agent.robot_say(args)
             elif command == "pickup":
                 logger.info(f"[Pickup task] Pickup: {args}")
                 target_object = args

--- a/src/stretch/app/ai_pickup.py
+++ b/src/stretch/app/ai_pickup.py
@@ -117,6 +117,14 @@ logger = Logger(__name__)
     is_flag=True,
     help="Set to print LLM responses to the console, to debug issues when parsing them when trying new LLMs.",
 )
+@click.option(
+    "--tts_target",
+    "--tts-target",
+    type=click.Choice(["robot", "pc"]),
+    default="robot",
+    show_default=True,
+    help="Where text-to-speech audio should play (robot or workstation).",
+)
 def main(
     robot_ip: str = "192.168.1.15",
     local: bool = False,
@@ -136,6 +144,7 @@ def main(
     realtime: bool = False,
     radius: float = 3.0,
     input_path: str = "",
+    tts_target: str = "robot",
 ):
     """Set up the robot, create a task plan, and execute it."""
     # Create robot
@@ -187,6 +196,7 @@ def main(
         available_actions=prompt.get_available_actions(),
         match_method=match_method,
         dry_run=False,
+        tts_target=tts_target,
     )
 
     # Get the LLM client


### PR DESCRIPTION
### Description

This PR introduces a new CLI option `--tts_target` to control where text-to-speech (TTS) audio is played when running `stretch.app.ai_pickup`.

Previously, all speech output was routed to the robot’s onboard speaker via the ROS2 bridge. This change adds flexibility by allowing users to instead play TTS audio locally on the workstation (e.g., GPU machine or connected speakers).

### Usage

```
# Default (robot speaker)
python -m stretch.app.ai_pickup --use_llm

# Workstation speaker
python -m stretch.app.ai_pickup --use_llm --tts_target pc
```